### PR TITLE
renamed to az-csvmware-cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ You can also use the extension from Azure Cloud Shell.
 
 ## Installing csvmware extension
 
-Download the [whl file](https://github.com/Azure/az-vmware-cli/blob/no_provider_apis/azext_vmware_cs/vmware_cs-0.1.0-py2.py3-none-any.whl) for the extension.
+Download the [whl file](https://github.com/Azure/az-csvmware-cli/blob/no_provider_apis/azext_vmware_cs/vmware_cs-0.1.0-py2.py3-none-any.whl) for the extension.
 Install by the CLI command:
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     description='Manage Azure VMware Solution by CloudSimple.',
     author='Shivam Mittal',
     author_email='shimitta@microsoft.com',
-    url='https://github.com/Azure/az-vmware-cli',
+    url='https://github.com/Azure/az-csvmware-cli',
     long_description=README + '\n\n' + HISTORY,
     license='MIT',
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
The repository has been renamed to `az-csvmware-cli` to match the renamed extension name. A pull request for the extension index is open as well https://github.com/Azure/azure-cli-extensions/pull/1681 .